### PR TITLE
fix: Forestry import button

### DIFF
--- a/docs/editing-in-forestry.md
+++ b/docs/editing-in-forestry.md
@@ -6,7 +6,7 @@ slug: forestry-cms
 ---
 ## Import starter
 
-[![](https://assets.forestry.io/import-to-forestryK.svg)](https://app.forestry.io/quick-start?repo=forestryio/jamdocs&engine=other "Import to Forestry")
+[![](https://assets.forestry.io/import-to-forestryK.svg)](https://app.forestry.io/quick-start?repo=samuelhorn/jamdocs&engine=other&preview=https://res.cloudinary.com/forestry-io/image/fetch/w_400,h_300,c_fill,f_jpg/https://forestry.io/img/starters/jamdocs.png "Import to Forestry")
 
 This project has been pre-configured to work with Forestry, just import your repository ✨
 Any changes you make will be commited back to the repo,


### PR DESCRIPTION
👋 some minor fix, now that the starter is live on Forestry:

- Link back to original repository
- Add preview thumbnail to the importer

Thanks for this slick documentation theme.
