### PR TITLE
Only load the config files globally

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -10,7 +10,7 @@ function addStyleResource (rule) {
     .loader('style-resources-loader')
     .options({
       patterns: [
-        path.resolve(__dirname, './src/assets/scss/globals.scss')
+        path.resolve(__dirname, './src/assets/scss/config/*.scss')
       ],
     })
 }

--- a/src/assets/scss/globals.scss
+++ b/src/assets/scss/globals.scss
@@ -1,7 +1,3 @@
-@import 'config/colors';
-@import 'config/maps';
-@import 'config/mixins';
-@import 'config/functions';
 @import 'prism';
 
 html {


### PR DESCRIPTION
globals.scss was previously getting prepended to itself, resulting in duplicated CSS code.