### PR TITLE
Fix issue #15, active subtopic "dot" not highlighting last active subtopic if topics are h3

### DIFF
--- a/src/templates/Doc.vue
+++ b/src/templates/Doc.vue
@@ -38,7 +38,7 @@ export default {
   opacity: .8;
 }
 
-/deep/ > h2 {
+/deep/ > h2, /deep/ > h3, /deep/ > h4, /deep/ > h5, /deep/ > h6 {
   padding-top: 100px;
   margin-top: -80px;
 


### PR DESCRIPTION
A friend requested that I fix [this issue](https://github.com/samuelhorn/jamdocs/issues/15) for them. 

After doing some digging, it appears to me that the dot in the Sidebar doesn't always appear because the heading can't reach a certain threshold from the top of the screen. This is because the styling related to `/deep` isn't applied to h3, h4, h5, and h6 elements.

I hope this changes fixes the issue or at least helps clarify things enough for you to fix it yourself.

Thanks for your open source project!